### PR TITLE
fix 表格脚设置最后显示，前面分页的页脚位置占位空白

### DIFF
--- a/src/hiprint/hiprint.bundle.js
+++ b/src/hiprint/hiprint.bundle.js
@@ -5549,7 +5549,7 @@ var hiprint = function (t) {
                 }
                 d.find("tbody").append(f);
                 var g = f.data("rowData");
-                l.push(g), h.push(g), (((s = d.outerHeight(), s += tfh) > p) || (this.options.maxRows && h.length > +this.options.maxRows)) && (a.prepend(f), l.pop(), h.pop(), s = d.outerHeight(), c = {
+                l.push(g), h.push(g), (((s = d.outerHeight(), "last" == this.options.tableFooterRepeat ? s : s += tfh) > p) || (this.options.maxRows && h.length > +this.options.maxRows)) && (a.prepend(f), l.pop(), h.pop(), s = d.outerHeight(), c = {
                   height: _assets_plugins_hinnn__WEBPACK_IMPORTED_MODULE_3__.a.px.toPt(s),
                   isEnd: !1
                 });


### PR DESCRIPTION
如果表格页脚有多行，将会有特别明显的空白
补丁：判断 last 选项后不加上 tfh(table foot height)

![2b7cc808e4bbd8b2dd1d16a0f7452b9d](https://github.com/CcSimple/vue-plugin-hiprint/assets/31088040/e01a6214-aa46-4f81-91a0-fc9fb5578934)

测试的 [json模板](https://oss.zurrtum.com/object/print.json)