### PR TITLE
fix: tablerender bug

### DIFF
--- a/src/hiprint/hiprint.bundle.js
+++ b/src/hiprint/hiprint.bundle.js
@@ -1884,7 +1884,8 @@ var hiprint = function (t) {
         var gff = h.getGroupFieldsFormatter(n, i);
         var groupRowIndex = 0;
         var groupFields = gff ? (n.groupFields = gff(i, n, e)) : i.groupFields ? i.groupFields : [];
-        (e || (e = []), groupFields.length) ? _assets_plugins_hinnn__WEBPACK_IMPORTED_MODULE_1__.a.groupBy(e, groupFields, function (t) {
+        e = Array.isArray(e) ? e : [];
+        groupFields.length ? _assets_plugins_hinnn__WEBPACK_IMPORTED_MODULE_1__.a.groupBy(e, groupFields, function (t) {
           var e = {};
           return groupFields.forEach(function (n) {
             return e[n] = t[n];


### PR DESCRIPTION
当表格测试数据不是数组时，如果表格渲染出现了bug TypeError: e.forEach is not a function 会导致全局的拖动 异常

复现方式，默认拖动设计demo演示中 ， 
1. 将表格的测试数据  改成 123 
2. 模板导出到 textarea
3. 然后 导出的json 通过左边更新json模板更新
4. 更新渲染之后 全局拖动异常

#150 