### PR TITLE
fix: 修复多表头列合并后， 设计和预览的列宽不一致的问题

### DIFF
--- a/src/hiprint/hiprint.bundle.js
+++ b/src/hiprint/hiprint.bundle.js
@@ -5697,7 +5697,7 @@ var hiprint = function (t) {
         if (this.printElementType.formatter) return (n = $("<div></div>")).append(this.printElementType.formatter(t)), (i = n.find("table")).addClass("hiprint-printElement-tableTarget"), i;
         var o = $('<table class="hiprint-printElement-tableTarget" style="border-collapse: collapse;"></table>');
         let headerList = _table_TableExcelHelper__WEBPACK_IMPORTED_MODULE_6__.a.createTableHead(this.getColumns(), this.options.getWidth() / this.options.getGridColumns());
-        return this.isNotDesign ? o.append(headerList) : o.append(headerList[0]), o.append(_table_TableExcelHelper__WEBPACK_IMPORTED_MODULE_6__.a.createTableRow(this.getColumns(), t, e, this.options, this.printElementType)), "no" == this.options.tableFooterRepeat || _table_TableExcelHelper__WEBPACK_IMPORTED_MODULE_6__.a.createTableFooter(this.printElementType.columns, t, this.options, this.printElementType, e, t).insertBefore(o.find("tbody")), o;
+        return (this.isNotDesign && ['first', 'none'].includes(this.options.tableHeaderRepeat)) ? o.append(headerList) : o.append(headerList[0]), o.append(_table_TableExcelHelper__WEBPACK_IMPORTED_MODULE_6__.a.createTableRow(this.getColumns(), t, e, this.options, this.printElementType)), "no" == this.options.tableFooterRepeat || _table_TableExcelHelper__WEBPACK_IMPORTED_MODULE_6__.a.createTableFooter(this.printElementType.columns, t, this.options, this.printElementType, e, t).insertBefore(o.find("tbody")), o;
       }, TablePrintElement.prototype.getEmptyRowTarget = function () {
         return _table_TableExcelHelper__WEBPACK_IMPORTED_MODULE_6__.a.createEmptyRowTarget(this.getColumns(), this);
       }, TablePrintElement.prototype.getHtml = function (t, e) {


### PR DESCRIPTION
![646a59fbe69c593fc612580f5cdfdfd](https://github.com/user-attachments/assets/b1127796-f60b-4505-a6fa-f03eaf8dcb35)
该问题并未完全解决，当`不显示`或者`首页显示`表头时,该问题还会复现。
完全解决需要在 `src/hiprint/hiprint.bundle.js` 完善 `TableExcelHelper.createTableHead` 下 `colgroup`的计算
![image](https://github.com/user-attachments/assets/0c55ee4d-c570-40cf-b8a4-ad476463c1ec)

