### PR TITLE
fix:修复模板数据复制后未选中当前元素的问题

### DIFF
--- a/src/hiprint/hiprint.bundle.js
+++ b/src/hiprint/hiprint.bundle.js
@@ -9865,9 +9865,9 @@ var hiprint = function (t) {
             console.log('pasteJson success');
             o.a.event.trigger("hiprintTemplateDataChanged_" + n.templateId, "复制");
             // 点击克隆出来的元素
+            ele.designTarget.trigger($.Event('blur'))
             a.designTarget.children('.resize-panel').trigger($.Event('click'));
             a.designTarget.trigger($.Event('focus'))
-            ele.designTarget.trigger($.Event('blur'))
           })
         } catch (e) {
           console.error('pasteJson error', e);

--- a/src/hiprint/hiprint.bundle.js
+++ b/src/hiprint/hiprint.bundle.js
@@ -9866,6 +9866,8 @@ var hiprint = function (t) {
             o.a.event.trigger("hiprintTemplateDataChanged_" + n.templateId, "复制");
             // 点击克隆出来的元素
             a.designTarget.children('.resize-panel').trigger($.Event('click'));
+            a.designTarget.trigger($.Event('focus'))
+            ele.designTarget.trigger($.Event('blur'))
           })
         } catch (e) {
           console.error('pasteJson error', e);


### PR DESCRIPTION
- 在复制模板数据后，触发新克隆元素的 click 事件- 添加触发设计目标元素的 focus 事件
- 添加触发原元素的 blur 事件，确保正确处理焦点变化
<img width="1916" height="908" alt="image" src="https://github.com/user-attachments/assets/c13163ad-2fb9-4ba7-bee4-fdfe04a1bf6f" />
