### PR TITLE
修复多面板下批量打印出现页码错误

### DIFF
--- a/src/hiprint/hiprint.bundle.js
+++ b/src/hiprint/hiprint.bundle.js
@@ -10623,10 +10623,10 @@ var hiprint = function (t) {
         e || (e = {});
         var i = $('<div class="hiprint-printTemplate"></div>');
         t && t.constructor === Array ? t.forEach(function (data,dataIndex) {
-          data && n.printPanels.forEach(function (n, o) {
-            i.append(n.getHtml(data, e));
+          data && n.printPanels.forEach(function (printPanel, o) {
+            i.append(printPanel.getHtml(data, e));
             // 批量打印 续排页码
-            if (dataIndex == t.length - 1) {
+            if (dataIndex == t.length - 1 && o == n.printPanels.length - 1) {
               delete hinnn._paperList;
             }
           });


### PR DESCRIPTION
多面板下批量打印数据时，只判断了dataIndex == t.length - 1，当执行到最后一条数据时，会立刻执行delete hinnn._paperList;，导致了这条数据后续的面板的页码都为1-1